### PR TITLE
Resource create api

### DIFF
--- a/api/resources/permissions.py
+++ b/api/resources/permissions.py
@@ -43,6 +43,14 @@ class ResourcesPermission:
         return proxy_object.has_permission(auth.user, self.REQUIRED_PERMISSIONS[request.method])
 
 
+class ResourceListPermission(ResourcesPermission, permissions.BasePermission):
+    '''Permissions for the top-level ResourceList endpoint.
+
+    ResourceList only supports POST
+    '''
+    REQUIRED_PERMISSIONS = {'POST': 'admin'}
+
+
 class ResourceDetailPermission(ResourcesPermission, permissions.BasePermission):
     '''Permissions for the top-level ResourcesDetail endpoint.
 

--- a/api/resources/serializers.py
+++ b/api/resources/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers as ser
 
+from api.base.exceptions import Conflict
 from api.base.serializers import (
     EnumField,
     JSONAPISerializer,
@@ -9,7 +10,8 @@ from api.base.serializers import (
     VersionedDateTimeField,
 )
 from api.base.utils import absolute_reverse
-from osf.utils.outcomes import ArtifactTypes
+from osf.models import Outcome, OutcomeArtifact, Registration
+from osf.utils.outcomes import ArtifactTypes, NoPIDError
 
 class ResourceSerializer(JSONAPISerializer):
 
@@ -60,3 +62,13 @@ class ResourceSerializer(JSONAPISerializer):
                 'resource_id': obj._id,
             },
         )
+
+    def create(self, validated_data):
+        primary_registration = Registration.load(self.context['request'].data['registration'])
+
+        try:
+            root_outcome = Outcome.objects.for_registration(primary_registration, create=True)
+        except NoPIDError:
+            raise Conflict('Cannot add Resrouces to a Registration without a DOI')
+
+        return OutcomeArtifact.objects.create(outcome=root_outcome)

--- a/api/resources/serializers.py
+++ b/api/resources/serializers.py
@@ -64,7 +64,13 @@ class ResourceSerializer(JSONAPISerializer):
         )
 
     def create(self, validated_data):
-        primary_registration = Registration.load(self.context['request'].data['registration'])
+        # Already loaded by view, so no need to error check
+        guid = self.context['request'].data['registration']
+        primary_registration = Registration.load(guid)
+        if not primary_registration.is_registration_approved:
+            raise Conflict(
+                f'Registration {guid} is pending approval and cannot have associated resources',
+            )
 
         try:
             root_outcome = Outcome.objects.for_registration(primary_registration, create=True)

--- a/api/resources/urls.py
+++ b/api/resources/urls.py
@@ -6,6 +6,10 @@ app_name = 'osf'
 
 urlpatterns = [
     url(
+        r'^$', views.ResourceList.as_view(), name=views.ResourceList.view_name,
+    ),
+
+    url(
         r'^(?P<resource_id>\w+)/$',
         views.ResourceDetail.as_view(),
         name=views.ResourceDetail.view_name,

--- a/api/resources/views.py
+++ b/api/resources/views.py
@@ -4,17 +4,49 @@ from rest_framework import generics, permissions as drf_permissions
 from rest_framework.exceptions import NotFound
 
 from api.base import permissions as base_permissions
+from api.base.exceptions import JSONAPIException
 from api.base.parsers import (
     JSONAPIMultipleRelationshipsParser,
     JSONAPIMultipleRelationshipsParserForRegularJSON,
 )
 from api.base.views import JSONAPIBaseView
-from api.resources.permissions import ResourceDetailPermission
+from api.resources.permissions import ResourceDetailPermission, ResourceListPermission
 from api.resources.serializers import ResourceSerializer
 from framework.auth.oauth_scopes import CoreScopes
-from osf.models import Guid, OutcomeArtifact
+from osf.models import Guid, OutcomeArtifact, Registration
 
 logger = logging.getLogger(__name__)
+
+
+class ResourceList(JSONAPIBaseView, generics.ListCreateAPIView):
+
+    permission_classes = (
+        ResourceListPermission,
+        drf_permissions.IsAuthenticatedOrReadOnly,
+        base_permissions.TokenHasScope,
+    )
+
+    required_read_scopes = [CoreScopes.READ_REGISTRATION_RESOURCES]
+    required_write_scopes = [CoreScopes.WRITE_REGISTRATION_RESOURCES]
+
+    view_category = 'resources'
+    view_name = 'resource-list'
+
+    serializer_class = ResourceSerializer
+
+    parser_classes = (JSONAPIMultipleRelationshipsParser, JSONAPIMultipleRelationshipsParserForRegularJSON)
+
+    def get_permissions_proxy(self):
+        try:
+            registration_guid = self.request.data['registration']
+        except KeyError:
+            raise JSONAPIException('Must provide "registration" relationship in payload"')
+
+        registration = Registration.load(registration_guid)
+        if not registration:
+            raise NotFound
+        return registration
+
 
 class ResourceDetail(JSONAPIBaseView, generics.RetrieveUpdateDestroyAPIView):
 

--- a/api_tests/resources/utils.py
+++ b/api_tests/resources/utils.py
@@ -1,0 +1,70 @@
+from django.utils import timezone
+
+from api.providers.workflows import Workflows as ModerationWorkflows
+from api_tests.utils import UserRoles
+from osf.models import Outcome
+from osf.utils.outcomes import ArtifactTypes
+from osf.utils.workflows import RegistrationModerationStates as RegStates
+from osf_tests.factories import (
+    AuthUserFactory,
+    RegistrationFactory,
+    RegistrationProviderFactory
+)
+
+TEST_EXTERNAL_PID = 'This is a doi'
+
+# Omitted the following redundant states:
+# PENDING_EMBARGO_TERMINATION (overlaps EMBARGO)
+# PENDING_WITHDRAW_REQESST and PENDING_WITHDRAW (ovrlaps ACCEPTED)
+# REVERTED (overlaps REJECTED)
+#
+# Techncically PENDING and EMBARGO overlap as well, but worth confirming EMBARGO behavior
+STATE_VISIBILITY_MAPPINGS = {
+    RegStates.INITIAL: {'public': False, 'deleted': False},
+    RegStates.PENDING: {'public': False, 'deleted': False},
+    RegStates.EMBARGO: {'public': False, 'deleted': False},
+    RegStates.ACCEPTED: {'public': True, 'deleted': False},
+    RegStates.WITHDRAWN: {'public': True, 'deleted': False},
+    RegStates.REJECTED: {'public': False, 'deleted': True},
+    # Use the generally unreachable UNDEFINED value for the edge case of deleted and public
+    RegStates.UNDEFINED: {'public': True, 'deleted': True},
+}
+
+
+def configure_test_preconditions(registration_state=RegStates.ACCEPTED, user_role=UserRoles.ADMIN_USER):
+    provider = RegistrationProviderFactory()
+    provider.update_group_permissions()
+    provider.reviews_workflow = ModerationWorkflows.PRE_MODERATION.value
+    provider.save()
+
+    state_settings = STATE_VISIBILITY_MAPPINGS[registration_state]
+    registration = RegistrationFactory(
+        provider=provider,
+        is_public=state_settings['public'],
+        has_doi=True
+    )
+    registration.moderation_state = registration_state.db_name
+    registration.deleted = timezone.now() if state_settings['deleted'] else None
+    registration.save()
+
+    outcome = Outcome.objects.for_registration(registration, create=True)
+    test_artifact = outcome.add_artifact_by_pid(
+        pid=TEST_EXTERNAL_PID, artifact_type=ArtifactTypes.DATA, create_identifier=True
+    )
+
+    test_auth = configure_test_auth(registration, user_role)
+
+    return test_artifact, test_auth, registration
+
+
+def configure_test_auth(registration, user_role):
+    if user_role is UserRoles.UNAUTHENTICATED:
+        return None
+
+    user = AuthUserFactory()
+    if user_role is UserRoles.MODERATOR:
+        registration.provider.get_group('moderator').user_set.add(user)
+    elif user_role in UserRoles.contributor_roles():
+        registration.add_contributor(user, user_role.get_permissions_string())
+
+    return user.auth

--- a/api_tests/resources/views/test_resource_list.py
+++ b/api_tests/resources/views/test_resource_list.py
@@ -1,0 +1,150 @@
+import pytest
+
+from django.utils import timezone
+
+from api_tests.resources.utils import configure_test_auth
+from api_tests.utils import UserRoles
+from osf.models import Outcome, OutcomeArtifact
+from osf.utils.outcomes import ArtifactTypes
+from osf.utils.workflows import RegistrationModerationStates as RegStates
+from osf_tests.factories import AuthUserFactory, RegistrationFactory
+
+POST_URL = '/v2/resources/'
+
+@pytest.fixture
+def admin_user():
+    return AuthUserFactory()
+
+
+@pytest.fixture
+def registration(admin_user):
+    return RegistrationFactory(creator=admin_user, is_public=True, has_doi=True)
+
+
+@pytest.fixture
+def payload(registration):
+    return {
+        'data': {
+            'type': 'resources',
+            'relationships': {
+                'registration': {
+                    'data': {
+                        'id': registration._id,
+                        'type': 'registrations'
+                    }
+                }
+            },
+        }
+    }
+
+@pytest.mark.django_db
+class TestResourceListPOSTPermissions:
+
+    def test_status_code__admin(self, app, registration, admin_user, payload):
+        resp = app.post_json_api(POST_URL, payload, auth=admin_user.auth, expect_errors=True)
+        assert resp.status_code == 201
+
+    @pytest.mark.parametrize('user_role', [role for role in UserRoles if role is not UserRoles.ADMIN_USER])
+    def test_status_code__non_admin(self, app, registration, payload, user_role):
+        test_auth = configure_test_auth(registration, UserRoles.ADMIN_USER)
+        resp = app.post_json_api(POST_URL, payload, auth=test_auth, expect_errors=True)
+        assert resp.status_code == 403 if test_auth else 401
+
+    @pytest.mark.parametrize('user_role', UserRoles)
+    def test_status_code__withdrawn_registration(self, app, registration, payload, user_role):
+        registration.moderation_state = RegStates.WITHDRAWN.db_name
+        registration.save()
+
+        test_auth = configure_test_auth(registration, UserRoles.ADMIN_USER)
+        resp = app.post_json_api(POST_URL, payload, auth=test_auth, expect_errors=True)
+        assert resp.status_code == 403 if test_auth else 401
+
+    @pytest.mark.parametrize('user_role', UserRoles)
+    def test_status_code__deleted_registration(self, app, registration, payload, user_role):
+        registration.deleted = timezone.now()
+        registration.save()
+
+        test_auth = configure_test_auth(registration, UserRoles.ADMIN_USER)
+        resp = app.post_json_api(POST_URL, payload, auth=test_auth, expect_errors=True)
+        assert resp.status_code == 410
+
+
+@pytest.mark.django_db
+class TestResourceListPOSTBehavior:
+
+    @pytest.fixture
+    def outcome(self, registration):
+        return Outcome.objects.for_registration(registration, create=True)
+
+    @pytest.fixture
+    def alternate_outcome(self, registration):
+        alternate_outcome = Outcome.objects.for_registration(
+            registration=RegistrationFactory(has_doi=True)
+        )
+        alternate_outcome.artifact_metadata.create(identifier=registration.get_identifier(category='doi'))
+        return alternate_outcome
+
+    def test_post_adds_artifact_to_existing_outcome(self, app, outcome, registration, admin_user, payload):
+        assert outcome.artifact_metadata.count() == 1
+
+        app.post_json_api(POST_URL, payload, auth=admin_user.auth, expect_errors=True)
+
+        assert outcome.artifact_metadata.count() == 2
+
+    def test_post_creates_outcome_and_primary_artifact_if_none_exists(self, app, registration, admin_user, payload):
+        assert not OutcomeArtifact.objects.exists()
+        assert not Outcome.objects.exists()
+
+        app.post_json_api(POST_URL, payload, auth=admin_user.auth, expect_errors=True)
+
+        created_outcome = Outcome.objects.for_registration(registration, create=False)
+        assert created_outcome is not None
+        assert created_outcome.artifact_metadata.count() == 2
+
+        primary_artifact = created_outcome.artifact_metadata.get(artifact_type=ArtifactTypes.PRIMARY)
+        assert primary_artifact.identifier == registration.get_identifier(category='doi')
+
+    def test_post_created_artifact_has_default_metadata(self, app, outcome, registration, admin_user, payload):
+        app.post_json_api(POST_URL, payload, auth=admin_user.auth, expect_errors=True)
+
+        created_artifact = outcome.artifact_metadata.order_by('-created').first()
+
+        assert not created_artifact.title
+        assert not created_artifact.description
+        assert not created_artifact.identifier
+        assert not created_artifact.pid
+        assert created_artifact.artifact_type == ArtifactTypes.UNDEFINED
+        assert created_artifact.primary_resource_guid == registration._id
+
+    def test_post_adds_artifact_to_primary_outcome_for_registration(
+        self, app, outcome, registration, admin_user, payload
+    ):
+        # Create an outcome where the Registration is *an* artifact but not the *primary* artifact
+        alternate_outcome = Outcome.objects.for_registration(
+            registration=RegistrationFactory(has_doi=True), create=True
+        )
+        alternate_outcome.artifact_metadata.create(identifier=registration.get_identifier(category='doi'))
+
+        assert alternate_outcome.artifact_metadata.count() == 2
+        assert outcome.artifact_metadata.count() == 1
+
+        app.post_json_api(POST_URL, payload, auth=admin_user.auth, expect_errors=True)
+
+        assert alternate_outcome.artifact_metadata.count() == 2
+        assert outcome.artifact_metadata.count() == 2
+
+    def test_post_fails_if_no_registration(self, app):
+        payload = {'data': {'type': 'resources'}}
+        resp = app.post_json_api(POST_URL, payload, auth=None, expect_errors=True)
+        assert resp.status_code == 400
+
+    def test_post_fails_with_404_if_registration_does_not_exist(self, app):
+        payload = {
+            'data': {
+                'type': 'resources',
+                'relationships': {'registration': {'data': {'id': 'QWERT', 'type': 'registrations'}}}
+            }
+        }
+
+        resp = app.post_json_api(POST_URL, payload, auth=None, expect_errors=True)
+        assert resp.status_code == 404

--- a/osf/models/outcome_artifacts.py
+++ b/osf/models/outcome_artifacts.py
@@ -82,7 +82,8 @@ class OutcomeArtifact(ObjectIDMixin, BaseModel):
     identifier = models.ForeignKey(
         'osf.identifier',
         on_delete=models.CASCADE,
-        related_name='artifact_metadata'
+        related_name='artifact_metadata',
+        null=True,
     )
 
     artifact_type = models.IntegerField(

--- a/osf/models/registrations.py
+++ b/osf/models/registrations.py
@@ -249,10 +249,15 @@ class Registration(AbstractNode):
 
     @property
     def is_registration_approved(self):
-        root = self._dirty_root
-        if root.registration_approval is None:
-            return False
-        return root.registration_approval.is_approved
+        pending_states = [
+            RegistrationModerationStates.INITIAL.db_name,
+            RegistrationModerationStates.PENDING.db_name
+        ]
+        return self.moderation_state not in pending_states
+#        root = self._dirty_root
+#        if root.registration_approval is None:
+#            return False
+#        return root.registration_approval.is_approved
 
     @property
     def is_pending_embargo(self):


### PR DESCRIPTION
<!-- Before submit your Pull Request, make sure you picked
     the right branch:

     - For hotfixes, select "master" as the target branch
     - For new features, select "develop" as the target branch
     - For release feature fixes, select the relevant release branch (release/X.Y.Z) as the target branch -->

## Purpose
Add the ResourceList endpoint with POST functionality

## Changes
* Add ResourceList View
  * Inspect the request's `data` to identify the Registration being POSTed to
* Add `create` functionality to ResourceSerializer
  * The first time a Resource is POSTed to a Registration, create the backing Outcome as well
  * Subsequent Resources should just be added to the same Outcome
* Make `identifier` NULLable on the `OutcomeArtifact`
  * Necessary, as POST does not include the `pid` information, just the Registration

## QA Notes
The Registration being POSTed to requires an Identifier, otherwise we cannot create the `PRIMARY` OutcomeArtifact. Right now, Registrations only get an Identifier when they are made public. That means `EMBARGOED` Registrations cannot have Resources.

I suggest we create an empty `Identifier` for each Registration once it is approved and wait to mint the actual DOI until it becomes public, but that can be a follow-on PR (note that this will not create wasted Identifiers, as, under existing workflows, every approved registration is guaranteed to become public).

## Documentation

<!-- Does any internal or external documentation need to be updated?
     - If the API was versioned, update the developer.osf.io changelog.
     - If changes were made to the API, link the developer.osf.io PR here.
-->

## Side Effects

<!-- Any possible side effects? -->

## Ticket

<!-- Link to JIRA ticket, if applicable e.g. https://openscience.atlassian.net/browse/OSF-1234 -->
